### PR TITLE
Remove R_LD_LIBRARY_PATH setup from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ before_install:
 
   - rm -rf ~/Downloads/julia*
   - export PATH="$HOME/julia/bin:$PATH"
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then export R_LD_LIBRARY_PATH="$(R RHOME)/lib:$HOME/julia/lib/julia"; fi
 
   - pip install --quiet tox-travis
 script:


### PR DESCRIPTION
Is it required for testing a Python package? If so, we need to put it in passenv http://tox.readthedocs.io/en/latest/config.html#confval-passenv=SPACE-SEPARATED-GLOBNAMES so that it can be referenced from environment inside tox.