### PR TITLE
Isolated Julia environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@ deps =
     pytest-cov
     numba
 commands =
+    julia --color=yes -e 'Pkg.init()'
     julia --color=yes -e 'Pkg.add("DiffEqPy")'
     julia --color=yes -e 'Pkg.checkout("PyCall")'
-    julia --color=yes -e 'Pkg.build("PyCall")'  # see PYTHON below
     julia --color=yes -e 'using DiffEqPy'
     python -c 'import diffeqpy.tests.test_ode'  # make sure import works
     py.test \
@@ -18,6 +18,10 @@ commands =
 whitelist_externals =
     julia
 setenv =
+    # Setup an isolated Julia environment for each tox environment.
+    # https://docs.julialang.org/en/latest/manual/environment-variables/#JULIA_PKGDIR-1
+    JULIA_PKGDIR = {envdir}/julia
+
     # Set Python interpreter to the one setup by tox.
     # See: https://github.com/JuliaPy/PyCall.jl#specifying-the-python-version
     PYTHON = {envpython}


### PR DESCRIPTION
One way to avoid `Pkg.build("PyCall")` and resulting re-compilation is to completely separate the whole Julia package installation.  Using JULIA_PKGDIR https://docs.julialang.org/en/latest/manual/environment-variables/#JULIA_PKGDIR-1 it's easy to do, at the cost of ~1 GB disk space.

It's probably too much for just avoiding `Pkg.build("PyCall")` :)