### PR TITLE
Allow tests to run without numba

### DIFF
--- a/diffeqpy/tests/test_dae.py
+++ b/diffeqpy/tests/test_dae.py
@@ -1,15 +1,16 @@
 import diffeqpy
 de = diffeqpy.setup()
 
-def f(du,u,p,t):
-  resid1 = - 0.04*u[0]               + 1e4*u[1]*u[2] - du[0]
-  resid2 = + 0.04*u[0] - 3e7*u[1]**2 - 1e4*u[1]*u[2] - du[1]
-  resid3 = u[0] + u[1] + u[2] - 1.0
-  return [resid1,resid2,resid3]
+def test_DAEProblem():
+    def f(du,u,p,t):
+        resid1 = - 0.04*u[0]               + 1e4*u[1]*u[2] - du[0]
+        resid2 = + 0.04*u[0] - 3e7*u[1]**2 - 1e4*u[1]*u[2] - du[1]
+        resid3 = u[0] + u[1] + u[2] - 1.0
+        return [resid1,resid2,resid3]
 
-u0 = [1.0, 0, 0]
-du0 = [-0.04, 0.04, 0.0]
-tspan = (0.0,100000.0)
-differential_vars = [True,True,False]
-prob = de.DAEProblem(f,du0,u0,tspan,differential_vars=differential_vars)
-sol = de.pysolve(prob)
+    u0 = [1.0, 0, 0]
+    du0 = [-0.04, 0.04, 0.0]
+    tspan = (0.0,100000.0)
+    differential_vars = [True,True,False]
+    prob = de.DAEProblem(f,du0,u0,tspan,differential_vars=differential_vars)
+    sol = de.pysolve(prob)

--- a/diffeqpy/tests/test_dde.py
+++ b/diffeqpy/tests/test_dde.py
@@ -1,15 +1,16 @@
 import diffeqpy
 de = diffeqpy.setup()
 
-def f(du,u,p,t):
-  resid1 = - 0.04*u[0]               + 1e4*u[1]*u[2] - du[0]
-  resid2 = + 0.04*u[0] - 3e7*u[1]**2 - 1e4*u[1]*u[2] - du[1]
-  resid3 = u[0] + u[1] + u[2] - 1.0
-  return [resid1,resid2,resid3]
+def test_DAEProblem():
+    def f(du,u,p,t):
+        resid1 = - 0.04*u[0]               + 1e4*u[1]*u[2] - du[0]
+        resid2 = + 0.04*u[0] - 3e7*u[1]**2 - 1e4*u[1]*u[2] - du[1]
+        resid3 = u[0] + u[1] + u[2] - 1.0
+        return [resid1,resid2,resid3]
 
-u0 = [1.0, 0, 0]
-du0 = [-0.04, 0.04, 0.0]
-tspan = (0.0,100000.0)
-differential_vars = [True,True,False]
-prob = de.DAEProblem(f,du0,u0,tspan,differential_vars=differential_vars)
-sol = de.pysolve(prob)
+    u0 = [1.0, 0, 0]
+    du0 = [-0.04, 0.04, 0.0]
+    tspan = (0.0,100000.0)
+    differential_vars = [True,True,False]
+    prob = de.DAEProblem(f,du0,u0,tspan,differential_vars=differential_vars)
+    sol = de.pysolve(prob)

--- a/diffeqpy/tests/test_ode.py
+++ b/diffeqpy/tests/test_ode.py
@@ -1,47 +1,64 @@
+try:
+    import numba
+except ImportError:
+    HAVE_NUMBA=False
+else:
+    HAVE_NUMBA=True
+
+import pytest
 import diffeqpy
 de = diffeqpy.setup()
-import numba
+
+def f1(u,p,t):
+    return -u
+
 
 def test_ode_sol():
-    def f(u,p,t):
-        return -u
-
     u0 = 0.5
     tspan = (0., 1.)
-    prob = de.ODEProblem(f, u0, tspan)
+    prob = de.ODEProblem(f1, u0, tspan)
     sol = de.pysolve(prob)
     assert len(sol.t) < 10
 
-    numba_f = numba.jit(f)
-    prob = de.ODEProblem(numba_f, u0, tspan)
+
+@pytest.mark.skipif(not HAVE_NUMBA, "The package 'numba' is needed for this test")
+def test_ode_sol_numba():
+    numba_f1 = numba.jit(f1)
+    prob = de.ODEProblem(numba_f1, u0, tspan)
     sol2 = de.pysolve(prob)
     assert len(sol.t) == len(sol2.t)
 
-def test_lorenz_sol():
-    def f(u,p,t):
-        x, y, z = u
-        sigma, rho, beta = p
-        return [sigma * (y - x), x * (rho - z) - y, x * y - beta * z]
 
+def f_lorenz(u,p,t):
+    x, y, z = u
+    sigma, rho, beta = p
+    return [sigma * (y - x), x * (rho - z) - y, x * y - beta * z]
+
+def test_lorenz_sol():
     u0 = [1.0,0.0,0.0]
     tspan = (0., 100.)
     p = [10.0,28.0,8/3]
-    prob = de.ODEProblem(f, u0, tspan, p)
+    prob = de.ODEProblem(f_lorenz, u0, tspan, p)
     sol = de.pysolve(prob)
 
-    def f(du,u,p,t):
-        x, y, z = u
-        sigma, rho, beta = p
-        du[0] = sigma * (y - x)
-        du[1] = x * (rho - z) - y
-        du[2] = x * y - beta * z
+def f_lorenz2(du,u,p,t):
+    x, y, z = u
+    sigma, rho, beta = p
+    du[0] = sigma * (y - x)
+    du[1] = x * (rho - z) - y
+    du[2] = x * y - beta * z
 
+
+def test_lorenz2_sol():
     u0 = [1.0,0.0,0.0]
     tspan = (0., 100.)
     p = [10.0,28.0,2.66]
-    prob = de.ODEProblem(f, u0, tspan, p)
+    prob = de.ODEProblem(f_lorenz2, u0, tspan, p)
     sol = de.pysolve(prob)
 
-    numba_f = numba.jit(f)
+
+@pytest.mark.skipif(not HAVE_NUMBA, "The package 'numba' is needed for this test")
+def test_lorenz2_sol_numba():
+    numba_f = numba.jit(f_lorenz2)
     prob = de.ODEProblem(numba_f, u0, tspan, p)
     sol2 = de.pysolve(prob)

--- a/diffeqpy/tests/test_sde.py
+++ b/diffeqpy/tests/test_sde.py
@@ -1,34 +1,46 @@
-import numba
+try:
+    import numba
+except ImportError:
+    HAVE_NUMBA=False
+else:
+    HAVE_NUMBA=True
+import pytest
 import diffeqpy
 de = diffeqpy.setup()
 
-def f(u,p,t):
-  return 1.01*u
 
-def g(u,p,t):
-  return 0.87*u
+def test_SDEProblem():
 
-u0 = 0.5
-tspan = (0.0,1.0)
-prob = de.SDEProblem(f,g,u0,tspan)
-sol = de.pysolve(prob)
+    def f(u,p,t):
+        return 1.01*u
 
-def f(du,u,p,t):
-    x, y, z = u
-    sigma, rho, beta = p
-    du[0] = sigma * (y - x)
-    du[1] = x * (rho - z) - y
-    du[2] = x * y - beta * z
+    def g(u,p,t):
+        return 0.87*u
 
-def g(du,u,p,t):
-    du[0] = 0.3*u[0]
-    du[1] = 0.3*u[1]
-    du[2] = 0.3*u[2]
+    u0 = 0.5
+    tspan = (0.0,1.0)
+    prob = de.SDEProblem(f,g,u0,tspan)
+    sol = de.pysolve(prob)
 
-numba_f = numba.jit(f)
-numba_g = numba.jit(g)
-u0 = [1.0,0.0,0.0]
-tspan = (0., 100.)
-p = [10.0,28.0,2.66]
-prob = de.SDEProblem(numba_f, numba_g, u0, tspan, p)
-sol = de.pysolve(prob)
+
+@pytest.mark.skipif(not HAVE_NUMBA, "The package 'numba' is needed for this test")
+def test_SDEProblem__numba():
+    def f(du,u,p,t):
+        x, y, z = u
+        sigma, rho, beta = p
+        du[0] = sigma * (y - x)
+        du[1] = x * (rho - z) - y
+        du[2] = x * y - beta * z
+
+    def g(du,u,p,t):
+        du[0] = 0.3*u[0]
+        du[1] = 0.3*u[1]
+        du[2] = 0.3*u[2]
+
+    numba_f = numba.jit(f)
+    numba_g = numba.jit(g)
+    u0 = [1.0,0.0,0.0]
+    tspan = (0., 100.)
+    p = [10.0,28.0,2.66]
+    prob = de.SDEProblem(numba_f, numba_g, u0, tspan, p)
+    sol = de.pysolve(prob)


### PR DESCRIPTION
- Refactored tests for "pytest-style"
- Conditionally run tests requiring numba
  Note that one can run pytest with the "-rs" flag to report
  on the reason for some tests being skipped.


Note that I haven't actually run these tests since I don't have Julia on this particular computer. Feel free to push into this branch if I messed up.