### PR TITLE
Use --startup-file=no & some README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,8 +371,3 @@ Unit tests can be run by [`tox`](http://tox.readthedocs.io).
 tox                # test with Python 3.6 and 2.7
 tox -e py36        # test only with Python 3.6
 ```
-
-**WARNING** `tox` isolates Python environment but not Julia
-environment.  In particular, you need to run `Pkg.free("PyCall")`
-and `Pkg.build("PyCall")` in Julia after running `tox` if you are
-using different Python interpreter in your default environment.

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,9 @@ deps =
     numba
 commands =
     julia --color=yes -e 'Pkg.init()'
-    julia --color=yes -e 'Pkg.add("DiffEqPy")'
-    julia --color=yes -e 'Pkg.checkout("PyCall")'
-    julia --color=yes -e 'using DiffEqPy'
+    julia --startup-file=no --color=yes -e 'Pkg.add("DiffEqPy")'
+    julia --startup-file=no --color=yes -e 'Pkg.checkout("PyCall")'
+    julia --startup-file=no --color=yes -e 'using DiffEqPy'
     python -c 'import diffeqpy.tests.test_ode'  # make sure import works
     py.test \
         --pyargs diffeqpy \


### PR DESCRIPTION
Now that we have #8, it's possible to isolate Julia environment further. I can now run `tox` without removing my `~/.juliarc.jl` even though it contains `ENV["PYTHON"] = ...`.

pyjulia still invokes `~/.juliarc.jl` via subprocess but it looks like it does not effect libjulia loaded in Python process  https://github.com/JuliaPy/pyjulia/blob/2eb704c33d6f639b41300023e16f910b5945600e/julia/core.py#L254-L270 (To be more precise, `'PYTHON' in julia.Julia().ENV` is false.)