### PR TITLE
Allow a workaround for "error initializing LibGit2 module"

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,8 +371,3 @@ Unit tests can be run by [`tox`](http://tox.readthedocs.io).
 tox                # test with Python 3.6 and 2.7
 tox -e py36        # test only with Python 3.6
 ```
-
-**WARNING** `tox` isolates Python environment but not Julia
-environment.  In particular, you need to run `Pkg.free("PyCall")`
-and `Pkg.build("PyCall")` in Julia after running `tox` if you are
-using different Python interpreter in your default environment.

--- a/README.md
+++ b/README.md
@@ -371,3 +371,17 @@ Unit tests can be run by [`tox`](http://tox.readthedocs.io).
 tox                # test with Python 3.6 and 2.7
 tox -e py36        # test only with Python 3.6
 ```
+
+### Troubleshooting
+
+In case you encounter silent failure from `tox`, try running it with
+`-- -s` (e.g., `tox -e py36 -- -s`) where `-s` option (`--capture=no`,
+i.e., don't capture stdio) is passed to `py.test`.  It may show an
+error message `"error initializing LibGit2 module"`.  In this case,
+setting environment variable `SSL_CERT_FILE` may help; e.g., try:
+
+```sh
+SSL_CERT_FILE=PATH/TO/cert.pem tox -e py36
+```
+
+See also: [julia#18693](https://github.com/JuliaLang/julia/issues/18693).

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,9 @@ deps =
     numba
 commands =
     julia --color=yes -e 'Pkg.init()'
-    julia --color=yes -e 'Pkg.add("DiffEqPy")'
-    julia --color=yes -e 'Pkg.checkout("PyCall")'
-    julia --color=yes -e 'using DiffEqPy'
+    julia --startup-file=no --color=yes -e 'Pkg.add("DiffEqPy")'
+    julia --startup-file=no --color=yes -e 'Pkg.checkout("PyCall")'
+    julia --startup-file=no --color=yes -e 'using DiffEqPy'
     python -c 'import diffeqpy.tests.test_ode'  # make sure import works
     py.test \
         --pyargs diffeqpy \

--- a/tox.ini
+++ b/tox.ini
@@ -28,3 +28,7 @@ setenv =
 
     # Do not use matplotlib GUI backend during tests.
     MPLBACKEND = agg
+passenv =
+    # Allow a workaround for "error initializing LibGit2 module":
+    # https://github.com/JuliaLang/julia/issues/18693
+    SSL_CERT_FILE


### PR DESCRIPTION
Finally, I can run the tests locally with this patch. It looks like the trouble I had was https://github.com/JuliaLang/julia/issues/18693

This is a patch on top of #12 to avoid conflict on README.md.