### PR TITLE
Allow Python 2 failure on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,10 @@ environment:
     - PYTHON: "C:\\Python36-x64"
       JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
 
+matrix:
+  allow_failures:
+    - PYTHON: "C:\\Python27-x64"
+
 notifications:
   - provider: Email
     on_build_success: false


### PR DESCRIPTION
Until #25 gets fixed, I suggest ignoring Python 2 failure on AppVeyor. It at least increases the entropy of CI results.