### PR TITLE
Remove llvmlite from deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ deps =
     pytest
     pytest-cov
     numba
-    llvmlite
 commands =
     python -c 'import diffeqpy; diffeqpy.install()'
     py.test \


### PR DESCRIPTION
It was introduced in fa9d4b4f90b9f490c5c2d80be5952b35de65f76b (#14) as at temporary workaround.  There is no need for this anymore.