### PR TITLE
Remove numba from the default test env and allow failures on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - rm -rf ~/Downloads/julia*
   - export PATH="$HOME/julia/bin:$PATH"
 
-  - pip install --quiet tox-travis
+  - pip install --quiet tox
 script:
 
   # Create an environment first so that we know what to use for $PYTHON:
@@ -32,3 +32,9 @@ script:
   - echo "$PYTHON"
 
   - tox -- --cov diffeqpy
+jobs:
+  include:
+    - env: TOXENV=py3-numba
+      python: "3.6"
+  allow_failures:
+    - env: TOXENV=py3-numba

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
 
-  TOXENV: py
   TOX_TESTENV_PASSENV: DISTUTILS_USE_SDK MSSdk INCLUDE LIB
   # https://packaging.python.org/guides/supporting-windows-using-appveyor/#testing-with-tox
 
@@ -11,8 +10,10 @@ environment:
 
     - PYTHONDIR: "C:\\Python27-x64"
       JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0-latest-win64.exe"
+      TOXENV: py
     - PYTHONDIR: "C:\\Python36-x64"
       JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0-latest-win64.exe"
+      TOXENV: py3-numba
 
 matrix:
   allow_failures:

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py2, py3
+envlist = py2, py3, py3-numba
 
 [testenv]
 deps =
     pytest
     pytest-cov
-    numba
 commands =
     python -c 'import diffeqpy; diffeqpy.install()'
     py.test \
@@ -25,3 +24,8 @@ passenv =
     # useful to specify this in CI so that `diffeqpy.install()` can
     # directly configure PyCall.
     PYTHON
+
+[testenv:py3-numba]
+deps =
+    {[testenv]deps}
+    numba


### PR DESCRIPTION
There are too many headaches with Numba.  I think it makes sense to isolate the test with Numba for now.