### PR TITLE
Fix tox usage on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ os:
 python:
     - "2.7"
     - "3.6"
+env:
+  global:
+    - TOXENV=py
 notifications:
   email: false
 before_install:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,3 @@
-[tox]
-envlist = py2, py3, py3-numba
-
 [testenv]
 deps =
     pytest


### PR DESCRIPTION
The change introduced in #48 accidentally made Travis run all tox
environments in one Travis job.  As I stopped using tox-travis, TOXENV
must be set manually.  There is also no need to list all envlist now.
